### PR TITLE
Dummy-ish commit to open a PR for notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,8 +79,6 @@ But, it does not make any sense to use this project without `mypy`.
 
 For this same reason, you cannot use `reveal_type` inside global scope of any Python file that will be executed for `django.setup()`.
 
-
-
 In other words, if your `manage.py runserver` crashes, mypy will crash too.
 You can also run `mypy` with [`--tb`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-show-traceback)
 option to get extra information about the error.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ To make `mypy` happy, you will need to add:
 [mypy]
 plugins =
     mypy_django_plugin.main
-    
+
 [mypy.plugins.django-stubs]
 django_settings_module = "myproject.settings"
 ```
 
 in your `mypy.ini` or `setup.cfg` [file](https://mypy.readthedocs.io/en/latest/config_file.html).
 
-Two things happeining here:
+Two things happening here:
 
 1. We need to explicitly list our plugin to be loaded by `mypy`
 2. Our plugin also requires `django` settings module (what you put into `DJANGO_SETTINGS_MODULE` variable) to be specified
@@ -73,15 +73,21 @@ But, it does not make any sense to use this project without `mypy`.
 
 ### mypy crashes when I run it with this plugin installed
 
-Current implementation uses Django runtime to extract models information, so it will crash, if your installed apps or `models.py` is not correct. For this same reason, you cannot use `reveal_type` inside global scope of any Python file that will be executed for `django.setup()`. 
+> ~Current implementation uses Django runtime to extract models information, so it will crash, if your installed apps or `models.py` is not correct.~
 
-In other words, if your `manage.py runserver` crashes, mypy will crash too. 
+^ This will change
+
+For this same reason, you cannot use `reveal_type` inside global scope of any Python file that will be executed for `django.setup()`.
+
+
+
+In other words, if your `manage.py runserver` crashes, mypy will crash too.
 You can also run `mypy` with [`--tb`](https://mypy.readthedocs.io/en/stable/command_line.html#cmdoption-mypy-show-traceback)
 option to get extra information about the error.
 
 ### I cannot use QuerySet or Manager with type annotations
 
-You can get a `TypeError: 'type' object is not subscriptable` 
+You can get a `TypeError: 'type' object is not subscriptable`
 when you will try to use `QuerySet[MyModel]` or `Manager[MyModel]`.
 
 This happens because Django classes do not support [`__class_getitem__`](https://www.python.org/dev/peps/pep-0560/#class-getitem) magic method.

--- a/mypy_django_plugin/django/context.py
+++ b/mypy_django_plugin/django/context.py
@@ -82,8 +82,8 @@ class LookupsAreUnsupported(Exception):
 
 
 class DjangoContext:
-    def __init__(self, django_settings_module: str) -> None:
-        self.django_settings_module = django_settings_module
+    def __init__(self, config: Dict[str, str]) -> None:
+        self.django_settings_module = config['django_settings_module']
 
         apps, settings = initialize_django(self.django_settings_module)
         self.apps_registry = apps


### PR DESCRIPTION
# I have made things!

Trying to use `django-stubs` together with a package that plays with Django settings, e.g. `django-configurations`, is a big pain due to interference (#417,  - from my experience most of the time people have to choose either one of the tools. Sadly, stubs are usually pushed aside since tools like `configurations` are in the project's foundation. 

This can also be a problem when people have custom apps configs (#224). 

One of the comments in #329 mentioned that work is being done to handle broken source code more graciously and to catch and report when the plugin crashes. This PR tackles a different issues, though very much related to how the plugin behaves considering external inconsistencies.   

## Related Issues
#417 (primary)
#224 - Very much related, workaround for `pylint`:
```ini
init-hook='
  import os, sys;
  from pylint.config import find_pylintrc;
  sys.path.append(os.path.join(os.path.dirname(find_pylintrc()), 'apps'))'
load-plugins=pylint_django, pylint_celery
``` 
[And a related previous PR](https://github.com/typeddjango/django-stubs/pull/180/files)

Format is:
- Closes #issue-number
- Refs #issue-number

Example. Refs #0
Documentation: https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/